### PR TITLE
Remove debug output from Nirmata provider

### DIFF
--- a/gollm/nirmata.go
+++ b/gollm/nirmata.go
@@ -475,7 +475,12 @@ func (c *NirmataClient) doRequestWithModel(ctx context.Context, endpoint, model 
 		}
 	}
 
-	return json.NewDecoder(httpResp.Body).Decode(resp)
+	bodyBytes, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response body: %w", err)
+	}
+
+	return json.Unmarshal(bodyBytes, resp)
 }
 
 func (c *nirmataChat) SetFunctionDefinitions(functions []*FunctionDefinition) error {


### PR DESCRIPTION
Clean up verbose HTTP response analysis that was cluttering logs. Maintain robust error handling and response parsing architecture.