### PR TITLE
Match tool result IDs to corresponding tool uses

### DIFF
--- a/gollm/bedrock.go
+++ b/gollm/bedrock.go
@@ -146,7 +146,7 @@ type bedrockChat struct {
 func (cs *bedrockChat) Initialize(history []*api.Message) error {
 	cs.messages = make([]types.Message, 0, len(history))
 
-	for _, msg := range history {
+	for i, msg := range history {
 		// Convert api.Message to types.Message
 		var role types.ConversationRole
 		switch msg.Source {
@@ -155,39 +155,228 @@ func (cs *bedrockChat) Initialize(history []*api.Message) error {
 		case api.MessageSourceModel, api.MessageSourceAgent:
 			role = types.ConversationRoleAssistant
 		default:
-			// Skip unknown message sources
+			klog.V(2).Infof("Skipping message %d: unknown source %s", i, msg.Source)
 			continue
 		}
 
-		// Convert payload to string content
-		var content string
-		if msg.Type == api.MessageTypeText && msg.Payload != nil {
-			if textPayload, ok := msg.Payload.(string); ok {
-				content = textPayload
-			} else {
-				// Try to convert other types to string
-				content = fmt.Sprintf("%v", msg.Payload)
-			}
-		} else {
-			// Skip non-text messages for now
+		// Process the message based on its type
+		contentBlocks, err := cs.processAPIMessage(msg)
+		if err != nil {
+			klog.V(2).Infof("Failed to process message %s: %v", msg.ID, err)
 			continue
 		}
 
-		if content == "" {
+		klog.V(2).Infof("Message %d: Generated %d content blocks", i, len(contentBlocks))
+		for j, block := range contentBlocks {
+			klog.V(2).Infof("  ContentBlock %d: %T", j, block)
+		}
+
+		if len(contentBlocks) == 0 {
+			klog.V(2).Infof("Skipping message %d: no content blocks generated", i)
 			continue
 		}
 
 		bedrockMsg := types.Message{
-			Role: role,
-			Content: []types.ContentBlock{
-				&types.ContentBlockMemberText{Value: content},
-			},
+			Role:    role,
+			Content: contentBlocks,
 		}
 
 		cs.messages = append(cs.messages, bedrockMsg)
 	}
 
+	klog.V(2).Infof("=== INITIALIZE - FINAL RESULT: %d MESSAGES ===", len(cs.messages))
 	return nil
+}
+
+// processAPIMessage converts an api.Message to Bedrock content blocks
+func (cs *bedrockChat) processAPIMessage(msg *api.Message) ([]types.ContentBlock, error) {
+	var contentBlocks []types.ContentBlock
+
+	klog.V(2).Infof("processAPIMessage: Processing message type %s", msg.Type)
+
+	switch msg.Type {
+	case api.MessageTypeText:
+		klog.V(2).Infof("processAPIMessage: Handling text message")
+		// Handle text messages
+		if msg.Payload != nil {
+			if textPayload, ok := msg.Payload.(string); ok && textPayload != "" {
+				contentBlocks = append(contentBlocks, &types.ContentBlockMemberText{Value: textPayload})
+				klog.V(2).Infof("processAPIMessage: Added text content block: %s", textPayload)
+			}
+		}
+
+	case api.MessageTypeToolCallRequest:
+		klog.V(2).Infof("processAPIMessage: Handling tool call request")
+		// Handle tool call requests (assistant messages with tool calls)
+		if msg.Payload != nil {
+			// The payload should contain tool call information
+			// This could be a map with tool call details or a structured object
+			if toolCallData, ok := msg.Payload.(map[string]any); ok {
+				klog.V(2).Infof("processAPIMessage: Tool call data: %+v", toolCallData)
+				toolUse, err := cs.createToolUseFromPayload(toolCallData)
+				if err != nil {
+					klog.V(2).Infof("processAPIMessage: Failed to create tool use: %v", err)
+					return nil, fmt.Errorf("failed to create tool use from payload: %w", err)
+				}
+				if toolUse != nil {
+					contentBlocks = append(contentBlocks, &types.ContentBlockMemberToolUse{Value: *toolUse})
+					klog.V(2).Infof("processAPIMessage: Added tool use content block")
+				}
+			} else {
+				klog.V(2).Infof("processAPIMessage: Payload is not map[string]any: %T", msg.Payload)
+			}
+		}
+
+	case api.MessageTypeToolCallResponse:
+		klog.V(2).Infof("processAPIMessage: Handling tool call response")
+		// Handle tool call responses (user messages with tool results)
+		if msg.Payload != nil {
+			// The payload should contain tool result information
+			if toolResultData, ok := msg.Payload.(map[string]any); ok {
+				klog.V(2).Infof("processAPIMessage: Tool result data: %+v", toolResultData)
+				toolResult, err := cs.createToolResultFromPayload(toolResultData)
+				if err != nil {
+					klog.V(2).Infof("processAPIMessage: Failed to create tool result: %v", err)
+					return nil, fmt.Errorf("failed to create tool result from payload: %w", err)
+				}
+				if toolResult != nil {
+					contentBlocks = append(contentBlocks, &types.ContentBlockMemberToolResult{Value: *toolResult})
+					klog.V(2).Infof("processAPIMessage: Added tool result content block")
+				}
+			} else {
+				klog.V(2).Infof("processAPIMessage: Payload is not map[string]any: %T", msg.Payload)
+			}
+		}
+
+	default:
+		klog.V(2).Infof("processAPIMessage: Handling unknown message type: %s", msg.Type)
+		// For unknown message types, try to extract text content
+		if msg.Payload != nil {
+			if textPayload, ok := msg.Payload.(string); ok && textPayload != "" {
+				contentBlocks = append(contentBlocks, &types.ContentBlockMemberText{Value: textPayload})
+				klog.V(2).Infof("processAPIMessage: Added text content block from unknown type: %s", textPayload)
+			}
+		}
+	}
+
+	klog.V(2).Infof("processAPIMessage: Generated %d content blocks", len(contentBlocks))
+	return contentBlocks, nil
+}
+
+// createToolUseFromPayload creates a ToolUseBlock from payload data
+func (cs *bedrockChat) createToolUseFromPayload(payload map[string]any) (*types.ToolUseBlock, error) {
+	// Extract required fields
+	toolUseID, hasID := payload["id"].(string)
+	if !hasID || toolUseID == "" {
+		return nil, fmt.Errorf("missing or invalid tool use ID")
+	}
+
+	name, hasName := payload["name"].(string)
+	if !hasName || name == "" {
+		return nil, fmt.Errorf("missing or invalid tool name")
+	}
+
+	// Extract arguments
+	var args map[string]any
+	if argsData, hasArgs := payload["arguments"]; hasArgs {
+		if argsMap, ok := argsData.(map[string]any); ok {
+			args = argsMap
+		} else if argsStr, ok := argsData.(string); ok {
+			// Try to parse JSON string
+			if err := json.Unmarshal([]byte(argsStr), &args); err != nil {
+				args = make(map[string]any)
+			}
+		}
+	}
+	if args == nil {
+		args = make(map[string]any)
+	}
+
+	return &types.ToolUseBlock{
+		ToolUseId: aws.String(toolUseID),
+		Name:      aws.String(name),
+		Input:     document.NewLazyDocument(args),
+	}, nil
+}
+
+// createToolResultFromPayload creates a ToolResultBlock from payload data
+func (cs *bedrockChat) createToolResultFromPayload(payload map[string]any) (*types.ToolResultBlock, error) {
+
+	// Extract required fields
+	toolUseID, hasID := payload["id"].(string)
+	if !hasID || toolUseID == "" {
+		return nil, fmt.Errorf("missing or invalid tool use ID")
+	}
+	klog.V(2).Infof("createToolResultFromPayload: ToolUseID: %s", toolUseID)
+
+	// Extract result content
+	var result map[string]any
+	if resultData, hasResult := payload["result"]; hasResult {
+		klog.V(2).Infof("createToolResultFromPayload: Result data: %+v (type: %T)", resultData, resultData)
+		if resultMap, ok := resultData.(map[string]any); ok {
+			result = resultMap
+			klog.V(2).Infof("createToolResultFromPayload: Using result as map: %+v", result)
+		} else {
+			// Wrap non-map results
+			result = map[string]any{"content": resultData}
+			klog.V(2).Infof("createToolResultFromPayload: Wrapped result: %+v", result)
+		}
+	}
+	if result == nil {
+		result = make(map[string]any)
+		klog.V(2).Infof("createToolResultFromPayload: Using empty result map")
+	}
+
+	// Determine status
+	status := types.ToolResultStatusSuccess
+	if statusVal, hasStatus := payload["status"]; hasStatus {
+		if statusStr, ok := statusVal.(string); ok {
+			if statusStr == "error" || statusStr == "failed" {
+				status = types.ToolResultStatusError
+			}
+		}
+	}
+	klog.V(2).Infof("createToolResultFromPayload: Final result: %+v, status: %s", result, status)
+
+	// Create the proper nested structure for tool results
+	// The structure should be: Content[0].Value = {Content: [{Value: resultData}], ToolUseId: "...", Status: "..."}
+	var contentValue map[string]any
+	if result != nil && len(result) > 0 {
+		contentValue = result
+	} else {
+		contentValue = make(map[string]any)
+	}
+
+	klog.V(2).Infof("createToolResultFromPayload: Content value: %+v", contentValue)
+
+	// Create the inner content structure with the actual result data
+	innerContent := []map[string]any{
+		{
+			"Value": contentValue,
+		},
+	}
+
+	// Create the outer structure
+	outerValue := map[string]any{
+		"Content":   innerContent,
+		"ToolUseId": toolUseID,
+		"Status":    string(status),
+	}
+
+	klog.V(2).Infof("createToolResultFromPayload: Outer value structure: %+v", outerValue)
+
+	toolResult := &types.ToolResultBlock{
+		ToolUseId: aws.String(toolUseID),
+		Content: []types.ToolResultContentBlock{
+			&types.ToolResultContentBlockMemberJson{
+				Value: document.NewLazyDocument(outerValue),
+			},
+		},
+		Status: status,
+	}
+
+	klog.V(2).Infof("createToolResultFromPayload: Created ToolResultBlock: %+v", toolResult)
+	return toolResult, nil
 }
 
 // Send sends a message to the chat and returns the response
@@ -196,11 +385,30 @@ func (c *bedrockChat) Send(ctx context.Context, contents ...any) (ChatResponse, 
 		return nil, errors.New("no content provided")
 	}
 
+	// Log the raw contents being processed
+	klog.V(2).Infof("=== SEND - RAW CONTENTS ===")
+	for i, content := range contents {
+		klog.V(2).Infof("Content %d: Type=%T, Value=%+v", i, content, content)
+	}
+
 	// Process contents to conversation history but don't commit yet
 	// Only commit to conversation history when the request succeeds
 	var contentBlocks []types.ContentBlock
 	if err := c.processContents(contents, &contentBlocks); err != nil {
 		return nil, err
+	}
+
+	// Log the processed content blocks
+	klog.V(2).Infof("=== SEND - PROCESSED CONTENT BLOCKS ===")
+
+	// Log the existing conversation history before adding new content
+	klog.V(2).Infof("=== SEND - EXISTING CONVERSATION HISTORY ===")
+	klog.V(2).Infof("Existing conversation history has %d messages", len(c.messages))
+	for i, msg := range c.messages {
+		klog.V(2).Infof("Existing Message %d: Role=%s, ContentBlocks=%d", i, msg.Role, len(msg.Content))
+		for j, cb := range msg.Content {
+			klog.V(2).Infof("  Existing ContentBlock %d: %#v", j, cb)
+		}
 	}
 
 	// Create a temporary message list that includes the new contents
@@ -213,6 +421,10 @@ func (c *bedrockChat) Send(ctx context.Context, contents ...any) (ChatResponse, 
 			Content: contentBlocks,
 		})
 	}
+
+	// Log the entire message history before sending the request
+	klog.V(2).Infof("=== SEND - FULL MESSAGE HISTORY ===")
+	klog.V(2).Infof("Total messages: %d", len(tempMessages))
 
 	// Prepare the request using temporary messages
 	input := &bedrockruntime.ConverseInput{
@@ -233,6 +445,13 @@ func (c *bedrockChat) Send(ctx context.Context, contents ...any) (ChatResponse, 
 	// Add tool configuration if functions are defined
 	if c.toolConfig != nil {
 		input.ToolConfig = c.toolConfig
+	}
+
+	// Log the input being sent to Bedrock
+	klog.V(2).Infof("=== BEDROCK CONVERSE INPUT ===")
+	klog.V(2).Infof("ModelId: %s, Messages: %d", *input.ModelId, len(input.Messages))
+	if input.ToolConfig != nil {
+		klog.V(2).Infof("ToolConfig: %+v", input.ToolConfig)
 	}
 
 	// Call the Bedrock Converse API
@@ -273,12 +492,25 @@ func (c *bedrockChat) SendStreaming(ctx context.Context, contents ...any) (ChatR
 		return nil, errors.New("no content provided")
 	}
 
+	// Log the raw contents being processed
+	klog.V(0).Infof("=== SENDSTREAMING - RAW CONTENTS ===")
+	for i, content := range contents {
+		klog.V(0).Infof("Content %d: Type=%T, Value=%+v", i, content, content)
+	}
+
 	// Process contents to conversation history but don't commit yet
 	// Only commit to conversation history when the request succeeds
 	var contentBlocks []types.ContentBlock
 	if err := c.processContents(contents, &contentBlocks); err != nil {
 		return nil, err
 	}
+
+	// Log the processed content blocks
+	klog.V(2).Infof("=== SENDSTREAMING - PROCESSED CONTENT BLOCKS ===")
+
+	// Log the existing conversation history before adding new content
+	klog.V(2).Infof("=== SENDSTREAMING - EXISTING CONVERSATION HISTORY ===")
+	klog.V(2).Infof("Existing conversation history has %d messages", len(c.messages))
 
 	// Create a temporary message list that includes the new contents
 	tempMessages := make([]types.Message, len(c.messages))
@@ -290,6 +522,10 @@ func (c *bedrockChat) SendStreaming(ctx context.Context, contents ...any) (ChatR
 			Content: contentBlocks,
 		})
 	}
+
+	// Log the entire message history before sending the streaming request
+	klog.V(2).Infof("=== SENDSTREAMING - FULL MESSAGE HISTORY ===")
+	klog.V(2).Infof("Total messages: %d", len(tempMessages))
 
 	// Prepare the streaming request using temporary messages
 	input := &bedrockruntime.ConverseStreamInput{
@@ -310,6 +546,13 @@ func (c *bedrockChat) SendStreaming(ctx context.Context, contents ...any) (ChatR
 	// Add tool configuration if functions are defined
 	if c.toolConfig != nil {
 		input.ToolConfig = c.toolConfig
+	}
+
+	// Log the input being sent to Bedrock
+	klog.V(2).Infof("=== BEDROCK CONVERSE STREAM INPUT ===")
+	klog.V(2).Infof("ModelId: %s, Messages: %d", *input.ModelId, len(input.Messages))
+	if input.ToolConfig != nil {
+		klog.V(2).Infof("ToolConfig: %+v", input.ToolConfig)
 	}
 
 	// Start the streaming request
@@ -472,7 +715,8 @@ func (c *bedrockChat) SendStreaming(ctx context.Context, contents ...any) (ChatR
 
 // processContents processes contents into content blocks without modifying conversation history
 func (c *bedrockChat) processContents(contents []any, contentBlocks *[]types.ContentBlock) error {
-	for _, content := range contents {
+	for i, content := range contents {
+		_ = i // avoid unused variable
 		switch v := content.(type) {
 		case string:
 			// Add text content block
@@ -504,9 +748,17 @@ func (c *bedrockChat) processContents(contents []any, contentBlocks *[]types.Con
 						Value: document.NewLazyDocument(v.Result),
 					},
 				},
-				Status: status,
+				Status: status, // only supoprted for Anthropic Claude 3 models???
 			}
 			*contentBlocks = append(*contentBlocks, &types.ContentBlockMemberToolResult{Value: toolResult})
+		case []interface{}:
+			// Process array of content items (e.g., user message with text and tool results)
+			for j, item := range v {
+				// Recursively process each item in the array
+				if err := c.processContents([]any{item}, contentBlocks); err != nil {
+					return fmt.Errorf("failed to process array item %d: %w", j, err)
+				}
+			}
 		default:
 			return fmt.Errorf("unhandled content type: %T", content)
 		}

--- a/gollm/bedrock.go
+++ b/gollm/bedrock.go
@@ -678,7 +678,7 @@ func (c *bedrockChat) processContents(contents []any, contentBlocks *[]types.Con
 						Value: document.NewLazyDocument(v.Result),
 					},
 				},
-				Status: status, // only supoprted for Anthropic Claude 3 models???
+				Status: status,
 			}
 			*contentBlocks = append(*contentBlocks, &types.ContentBlockMemberToolResult{Value: toolResult})
 		case []interface{}:

--- a/gollm/bedrock_tools_test.go
+++ b/gollm/bedrock_tools_test.go
@@ -1,0 +1,711 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gollm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/api"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+)
+
+func TestCreateToolUseFromPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]any
+		wantErr bool
+		check   func(t *testing.T, result *types.ToolUseBlock)
+	}{
+		{
+			name: "valid tool use with arguments map",
+			payload: map[string]any{
+				"id":   "call-123",
+				"name": "kubectl_get",
+				"arguments": map[string]any{
+					"resource": "pods",
+					"flags":    []string{"-n", "default"},
+				},
+			},
+			wantErr: false,
+			check: func(t *testing.T, result *types.ToolUseBlock) {
+				if result == nil {
+					t.Fatal("expected non-nil result")
+				}
+				if aws.ToString(result.ToolUseId) != "call-123" {
+					t.Errorf("expected tool use id 'call-123', got %s", aws.ToString(result.ToolUseId))
+				}
+				if aws.ToString(result.Name) != "kubectl_get" {
+					t.Errorf("expected name 'kubectl_get', got %s", aws.ToString(result.Name))
+				}
+			},
+		},
+		{
+			name: "valid tool use with arguments as JSON string",
+			payload: map[string]any{
+				"id":        "call-456",
+				"name":      "shell_exec",
+				"arguments": `{"command":"ls -la"}`,
+			},
+			wantErr: false,
+			check: func(t *testing.T, result *types.ToolUseBlock) {
+				if result == nil {
+					t.Fatal("expected non-nil result")
+				}
+				if aws.ToString(result.ToolUseId) != "call-456" {
+					t.Errorf("expected tool use id 'call-456', got %s", aws.ToString(result.ToolUseId))
+				}
+			},
+		},
+		{
+			name: "missing tool use id",
+			payload: map[string]any{
+				"name":      "kubectl_get",
+				"arguments": map[string]any{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty tool use id",
+			payload: map[string]any{
+				"id":        "",
+				"name":      "kubectl_get",
+				"arguments": map[string]any{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing tool name",
+			payload: map[string]any{
+				"id":        "call-789",
+				"arguments": map[string]any{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty tool name",
+			payload: map[string]any{
+				"id":        "call-789",
+				"name":      "",
+				"arguments": map[string]any{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no arguments provided",
+			payload: map[string]any{
+				"id":   "call-000",
+				"name": "simple_tool",
+			},
+			wantErr: false,
+			check: func(t *testing.T, result *types.ToolUseBlock) {
+				if result == nil {
+					t.Fatal("expected non-nil result")
+				}
+				// Should have empty args map
+			},
+		},
+	}
+
+	cs := &bedrockChat{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := cs.createToolUseFromPayload(tt.payload)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createToolUseFromPayload() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+func TestCreateToolResultFromPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]any
+		wantErr bool
+		check   func(t *testing.T, result *types.ToolResultBlock)
+	}{
+		{
+			name: "successful tool result with map",
+			payload: map[string]any{
+				"id": "call-123",
+				"result": map[string]any{
+					"output": "pod1\npod2\npod3",
+					"status": "success",
+				},
+			},
+			wantErr: false,
+			check: func(t *testing.T, result *types.ToolResultBlock) {
+				if result == nil {
+					t.Fatal("expected non-nil result")
+				}
+				if aws.ToString(result.ToolUseId) != "call-123" {
+					t.Errorf("expected tool use id 'call-123', got %s", aws.ToString(result.ToolUseId))
+				}
+				if result.Status != types.ToolResultStatusSuccess {
+					t.Errorf("expected status Success, got %s", result.Status)
+				}
+				if len(result.Content) == 0 {
+					t.Error("expected non-empty content")
+				}
+			},
+		},
+		{
+			name: "tool result with error status",
+			payload: map[string]any{
+				"id":     "call-456",
+				"status": "error",
+				"result": map[string]any{
+					"error": "command not found",
+				},
+			},
+			wantErr: false,
+			check: func(t *testing.T, result *types.ToolResultBlock) {
+				if result == nil {
+					t.Fatal("expected non-nil result")
+				}
+				if result.Status != types.ToolResultStatusError {
+					t.Errorf("expected status Error, got %s", result.Status)
+				}
+			},
+		},
+		{
+			name: "tool result with failed status",
+			payload: map[string]any{
+				"id":     "call-789",
+				"status": "failed",
+				"result": map[string]any{
+					"message": "operation failed",
+				},
+			},
+			wantErr: false,
+			check: func(t *testing.T, result *types.ToolResultBlock) {
+				if result == nil {
+					t.Fatal("expected non-nil result")
+				}
+				if result.Status != types.ToolResultStatusError {
+					t.Errorf("expected status Error, got %s", result.Status)
+				}
+			},
+		},
+		{
+			name: "tool result with non-map result (wrapped)",
+			payload: map[string]any{
+				"id":     "call-000",
+				"result": "simple string result",
+			},
+			wantErr: false,
+			check: func(t *testing.T, result *types.ToolResultBlock) {
+				if result == nil {
+					t.Fatal("expected non-nil result")
+				}
+				// Non-map results should be wrapped
+			},
+		},
+		{
+			name: "missing tool use id",
+			payload: map[string]any{
+				"result": map[string]any{"output": "test"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty tool use id",
+			payload: map[string]any{
+				"id":     "",
+				"result": map[string]any{"output": "test"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no result provided",
+			payload: map[string]any{
+				"id": "call-999",
+			},
+			wantErr: false,
+			check: func(t *testing.T, result *types.ToolResultBlock) {
+				if result == nil {
+					t.Fatal("expected non-nil result")
+				}
+				// Should have empty result
+			},
+		},
+	}
+
+	cs := &bedrockChat{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := cs.createToolResultFromPayload(tt.payload)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createToolResultFromPayload() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+func TestProcessAPIMessage(t *testing.T) {
+	tests := []struct {
+		name      string
+		message   *api.Message
+		wantErr   bool
+		wantCount int
+		check     func(t *testing.T, blocks []types.ContentBlock)
+	}{
+		{
+			name: "text message",
+			message: &api.Message{
+				ID:      "msg-1",
+				Source:  api.MessageSourceUser,
+				Type:    api.MessageTypeText,
+				Payload: "Hello, world!",
+			},
+			wantErr:   false,
+			wantCount: 1,
+			check: func(t *testing.T, blocks []types.ContentBlock) {
+				if len(blocks) != 1 {
+					t.Fatalf("expected 1 content block, got %d", len(blocks))
+				}
+				if _, ok := blocks[0].(*types.ContentBlockMemberText); !ok {
+					t.Errorf("expected ContentBlockMemberText, got %T", blocks[0])
+				}
+			},
+		},
+		{
+			name: "empty text message",
+			message: &api.Message{
+				ID:      "msg-2",
+				Source:  api.MessageSourceUser,
+				Type:    api.MessageTypeText,
+				Payload: "",
+			},
+			wantErr:   false,
+			wantCount: 0,
+		},
+		{
+			name: "tool call request",
+			message: &api.Message{
+				ID:     "msg-3",
+				Source: api.MessageSourceModel,
+				Type:   api.MessageTypeToolCallRequest,
+				Payload: map[string]any{
+					"id":   "call-123",
+					"name": "kubectl_get",
+					"arguments": map[string]any{
+						"resource": "pods",
+					},
+				},
+			},
+			wantErr:   false,
+			wantCount: 1,
+			check: func(t *testing.T, blocks []types.ContentBlock) {
+				if len(blocks) != 1 {
+					t.Fatalf("expected 1 content block, got %d", len(blocks))
+				}
+				if _, ok := blocks[0].(*types.ContentBlockMemberToolUse); !ok {
+					t.Errorf("expected ContentBlockMemberToolUse, got %T", blocks[0])
+				}
+			},
+		},
+		{
+			name: "tool call request with invalid payload",
+			message: &api.Message{
+				ID:      "msg-4",
+				Source:  api.MessageSourceModel,
+				Type:    api.MessageTypeToolCallRequest,
+				Payload: "invalid-not-a-map",
+			},
+			wantErr:   false,
+			wantCount: 0,
+		},
+		{
+			name: "tool call response",
+			message: &api.Message{
+				ID:     "msg-5",
+				Source: api.MessageSourceUser,
+				Type:   api.MessageTypeToolCallResponse,
+				Payload: map[string]any{
+					"id": "call-123",
+					"result": map[string]any{
+						"output": "pod1\npod2",
+					},
+				},
+			},
+			wantErr:   false,
+			wantCount: 1,
+			check: func(t *testing.T, blocks []types.ContentBlock) {
+				if len(blocks) != 1 {
+					t.Fatalf("expected 1 content block, got %d", len(blocks))
+				}
+				if _, ok := blocks[0].(*types.ContentBlockMemberToolResult); !ok {
+					t.Errorf("expected ContentBlockMemberToolResult, got %T", blocks[0])
+				}
+			},
+		},
+		{
+			name: "tool call response with invalid payload",
+			message: &api.Message{
+				ID:      "msg-6",
+				Source:  api.MessageSourceUser,
+				Type:    api.MessageTypeToolCallResponse,
+				Payload: "invalid-not-a-map",
+			},
+			wantErr:   false,
+			wantCount: 0,
+		},
+		{
+			name: "nil payload",
+			message: &api.Message{
+				ID:      "msg-7",
+				Source:  api.MessageSourceUser,
+				Type:    api.MessageTypeText,
+				Payload: nil,
+			},
+			wantErr:   false,
+			wantCount: 0,
+		},
+		{
+			name: "unknown message type with text payload",
+			message: &api.Message{
+				ID:      "msg-8",
+				Source:  api.MessageSourceUser,
+				Type:    api.MessageTypeUserInputRequest,
+				Payload: "Some text content",
+			},
+			wantErr:   false,
+			wantCount: 1,
+			check: func(t *testing.T, blocks []types.ContentBlock) {
+				if len(blocks) != 1 {
+					t.Fatalf("expected 1 content block, got %d", len(blocks))
+				}
+				// Should fall back to text for unknown types
+				if _, ok := blocks[0].(*types.ContentBlockMemberText); !ok {
+					t.Errorf("expected ContentBlockMemberText for unknown type, got %T", blocks[0])
+				}
+			},
+		},
+	}
+
+	cs := &bedrockChat{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks, err := cs.processAPIMessage(tt.message)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("processAPIMessage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(blocks) != tt.wantCount {
+				t.Errorf("processAPIMessage() returned %d blocks, want %d", len(blocks), tt.wantCount)
+			}
+			if !tt.wantErr && tt.check != nil {
+				tt.check(t, blocks)
+			}
+		})
+	}
+}
+
+func TestProcessAPIMessageWithMalformedToolData(t *testing.T) {
+	cs := &bedrockChat{}
+
+	tests := []struct {
+		name    string
+		message *api.Message
+		wantErr bool
+	}{
+		{
+			name: "tool call request missing id",
+			message: &api.Message{
+				Type: api.MessageTypeToolCallRequest,
+				Payload: map[string]any{
+					"name":      "kubectl_get",
+					"arguments": map[string]any{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "tool call request missing name",
+			message: &api.Message{
+				Type: api.MessageTypeToolCallRequest,
+				Payload: map[string]any{
+					"id":        "call-123",
+					"arguments": map[string]any{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "tool call response missing id",
+			message: &api.Message{
+				Type: api.MessageTypeToolCallResponse,
+				Payload: map[string]any{
+					"result": map[string]any{"output": "test"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := cs.processAPIMessage(tt.message)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("processAPIMessage() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestInitializeWithToolMessages(t *testing.T) {
+	cs := &bedrockChat{}
+
+	history := []*api.Message{
+		{
+			ID:      "msg-1",
+			Source:  api.MessageSourceUser,
+			Type:    api.MessageTypeText,
+			Payload: "get all pods",
+		},
+		{
+			ID:     "msg-2",
+			Source: api.MessageSourceModel,
+			Type:   api.MessageTypeToolCallRequest,
+			Payload: map[string]any{
+				"id":   "call-123",
+				"name": "kubectl_get",
+				"arguments": map[string]any{
+					"resource": "pods",
+				},
+			},
+		},
+		{
+			ID:     "msg-3",
+			Source: api.MessageSourceUser,
+			Type:   api.MessageTypeToolCallResponse,
+			Payload: map[string]any{
+				"id": "call-123",
+				"result": map[string]any{
+					"output": "pod1\npod2\npod3",
+				},
+			},
+		},
+		{
+			ID:      "msg-4",
+			Source:  api.MessageSourceModel,
+			Type:    api.MessageTypeText,
+			Payload: "Here are the pods in your cluster",
+		},
+	}
+
+	err := cs.Initialize(history)
+	if err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+
+	// Should have 4 messages in the conversation
+	if len(cs.messages) != 4 {
+		t.Errorf("expected 4 messages in conversation, got %d", len(cs.messages))
+	}
+
+	// Check message roles
+	expectedRoles := []types.ConversationRole{
+		types.ConversationRoleUser,
+		types.ConversationRoleAssistant,
+		types.ConversationRoleUser,
+		types.ConversationRoleAssistant,
+	}
+
+	for i, msg := range cs.messages {
+		if msg.Role != expectedRoles[i] {
+			t.Errorf("message %d: expected role %s, got %s", i, expectedRoles[i], msg.Role)
+		}
+	}
+
+	// Check content block types
+	if len(cs.messages[0].Content) != 1 {
+		t.Errorf("message 0: expected 1 content block, got %d", len(cs.messages[0].Content))
+	} else if _, ok := cs.messages[0].Content[0].(*types.ContentBlockMemberText); !ok {
+		t.Errorf("message 0: expected text content, got %T", cs.messages[0].Content[0])
+	}
+
+	if len(cs.messages[1].Content) != 1 {
+		t.Errorf("message 1: expected 1 content block, got %d", len(cs.messages[1].Content))
+	} else if _, ok := cs.messages[1].Content[0].(*types.ContentBlockMemberToolUse); !ok {
+		t.Errorf("message 1: expected tool use content, got %T", cs.messages[1].Content[0])
+	}
+
+	if len(cs.messages[2].Content) != 1 {
+		t.Errorf("message 2: expected 1 content block, got %d", len(cs.messages[2].Content))
+	} else if _, ok := cs.messages[2].Content[0].(*types.ContentBlockMemberToolResult); !ok {
+		t.Errorf("message 2: expected tool result content, got %T", cs.messages[2].Content[0])
+	}
+
+	if len(cs.messages[3].Content) != 1 {
+		t.Errorf("message 3: expected 1 content block, got %d", len(cs.messages[3].Content))
+	} else if _, ok := cs.messages[3].Content[0].(*types.ContentBlockMemberText); !ok {
+		t.Errorf("message 3: expected text content, got %T", cs.messages[3].Content[0])
+	}
+}
+
+func TestInitializeSkipsInvalidMessages(t *testing.T) {
+	cs := &bedrockChat{}
+
+	history := []*api.Message{
+		{
+			ID:      "msg-1",
+			Source:  api.MessageSourceUser,
+			Type:    api.MessageTypeText,
+			Payload: "valid message",
+		},
+		{
+			ID:      "msg-2",
+			Source:  "unknown-source",
+			Type:    api.MessageTypeText,
+			Payload: "message with unknown source",
+		},
+		{
+			ID:      "msg-3",
+			Source:  api.MessageSourceUser,
+			Type:    api.MessageTypeText,
+			Payload: "", // empty text
+		},
+		{
+			ID:     "msg-4",
+			Source: api.MessageSourceModel,
+			Type:   api.MessageTypeToolCallRequest,
+			Payload: map[string]any{
+				// missing required fields
+				"arguments": map[string]any{},
+			},
+		},
+		{
+			ID:      "msg-5",
+			Source:  api.MessageSourceUser,
+			Type:    api.MessageTypeText,
+			Payload: "another valid message",
+		},
+	}
+
+	err := cs.Initialize(history)
+	if err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+
+	// Should only have the 2 valid messages
+	if len(cs.messages) != 2 {
+		t.Errorf("expected 2 valid messages in conversation, got %d", len(cs.messages))
+	}
+}
+
+func TestToolUseArgumentsParsing(t *testing.T) {
+	cs := &bedrockChat{}
+
+	// Test with valid JSON string arguments
+	payload := map[string]any{
+		"id":        "call-123",
+		"name":      "test_tool",
+		"arguments": `{"key1":"value1","key2":42,"key3":true}`,
+	}
+
+	result, err := cs.createToolUseFromPayload(payload)
+	if err != nil {
+		t.Fatalf("createToolUseFromPayload() failed: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Test with invalid JSON string arguments (should default to empty map)
+	payloadInvalid := map[string]any{
+		"id":        "call-456",
+		"name":      "test_tool",
+		"arguments": `{invalid json`,
+	}
+
+	result2, err := cs.createToolUseFromPayload(payloadInvalid)
+	if err != nil {
+		t.Fatalf("createToolUseFromPayload() with invalid JSON failed: %v", err)
+	}
+
+	if result2 == nil {
+		t.Fatal("expected non-nil result for invalid JSON")
+	}
+}
+
+func TestToolResultWithComplexStructure(t *testing.T) {
+	cs := &bedrockChat{}
+
+	payload := map[string]any{
+		"id": "call-789",
+		"result": map[string]any{
+			"output": "command output here",
+			"metadata": map[string]any{
+				"duration": 1.5,
+				"exitCode": 0,
+			},
+			"warnings": []string{"warning1", "warning2"},
+		},
+		"status": "success",
+	}
+
+	result, err := cs.createToolResultFromPayload(payload)
+	if err != nil {
+		t.Fatalf("createToolResultFromPayload() failed: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if aws.ToString(result.ToolUseId) != "call-789" {
+		t.Errorf("expected tool use id 'call-789', got %s", aws.ToString(result.ToolUseId))
+	}
+
+	if result.Status != types.ToolResultStatusSuccess {
+		t.Errorf("expected status Success, got %s", result.Status)
+	}
+
+	if len(result.Content) == 0 {
+		t.Error("expected non-empty content")
+	}
+
+	// Verify content structure
+	if jsonBlock, ok := result.Content[0].(*types.ToolResultContentBlockMemberJson); ok {
+		// Try to marshal and unmarshal to verify structure
+		data, err := json.Marshal(jsonBlock.Value)
+		if err != nil {
+			t.Errorf("failed to marshal json block: %v", err)
+		}
+
+		var unmarshaled map[string]any
+		if err := json.Unmarshal(data, &unmarshaled); err != nil {
+			t.Errorf("failed to unmarshal json block: %v", err)
+		}
+	} else {
+		t.Errorf("expected ToolResultContentBlockMemberJson, got %T", result.Content[0])
+	}
+}

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubectl-ai/pkg/journal"
 	"github.com/google/uuid"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
@@ -152,9 +151,6 @@ type InvokeToolOptions struct {
 
 	// Kubeconfig is the path to the kubeconfig file.
 	Kubeconfig string
-
-	// CallID is the ID to use for this tool call. If empty, a new UUID will be generated.
-	CallID string
 }
 
 type ToolRequestEvent struct {
@@ -173,15 +169,7 @@ type ToolResponseEvent struct {
 func (t *ToolCall) InvokeTool(ctx context.Context, opt InvokeToolOptions) (any, error) {
 	recorder := journal.RecorderFromContext(ctx)
 
-	// Use provided CallID or generate a new one
-	callID := opt.CallID
-	if callID == "" {
-		callID = uuid.NewString()
-		klog.V(2).Infof("Generated new callID: %s", callID)
-	} else {
-		klog.V(2).Infof("Using provided callID: %s", callID)
-	}
-
+	callID := uuid.NewString()
 	recorder.Write(ctx, &journal.Event{
 		Timestamp: time.Now(),
 		Action:    "tool-request",


### PR DESCRIPTION
- Allow tool results to have IDs declaratively passed into their constructor
- Utilize APIMessages in Nirmata Provider's client-side message history, and expect APIMessages to be passed into the Bedrock provider via the chat endpoint