### PR TITLE
feat(bedrock): adaptive thinking + effort support for Claude 4.6

### DIFF
--- a/gollm/bedrock.go
+++ b/gollm/bedrock.go
@@ -128,6 +128,8 @@ func (c *BedrockClient) SetResponseSchema(schema *Schema) error {
 // ListModels returns the list of supported Bedrock models
 func (c *BedrockClient) ListModels(ctx context.Context) ([]string, error) {
 	return []string{
+		"global.anthropic.claude-sonnet-4-6",           // Claude Sonnet 4.6 (adaptive thinking + effort)
+		"global.anthropic.claude-opus-4-6",             // Claude Opus 4.6 (adaptive thinking + effort)
 		"us.anthropic.claude-sonnet-4-20250514-v1:0",   // Claude Sonnet 4 (default)
 		"us.anthropic.claude-3-7-sonnet-20250219-v1:0", // Claude 3.7 Sonnet
 	}, nil
@@ -141,6 +143,27 @@ type bedrockChat struct {
 	messages     []types.Message
 	toolConfig   *types.ToolConfiguration
 	functionDefs []*FunctionDefinition
+
+	// thinkingMode and effort control extended thinking behavior on Claude 4.6
+	// models (Sonnet 4.6, Opus 4.6) via Bedrock. Both are empty by default,
+	// in which case no additionalModelRequestFields are sent and behavior is
+	// identical to the pre-existing Bedrock provider for all other models.
+	// Set via SetThinkingConfig.
+	//
+	// Valid thinkingMode values: "" (off), "adaptive", "disabled".
+	// Valid effort values: "" (off, server defaults to high), "low", "medium",
+	// "high", "max". The library does not validate these — Bedrock returns an
+	// error for unsupported combinations (e.g. effort on a non-4.6 model),
+	// and that error is propagated through wrapAWSError unchanged.
+	thinkingMode string
+	effort       string
+
+	// thinkingExtras is the smithy document built from thinkingMode/effort.
+	// It is constructed once in SetThinkingConfig and reused on every
+	// Send/SendStreaming call, instead of rebuilding the map and document
+	// wrapper on every turn of an agentic loop. nil ⇒ leave
+	// AdditionalModelRequestFields unset on the request.
+	thinkingExtras document.Interface
 }
 
 func (cs *bedrockChat) Initialize(history []*api.Message) error {
@@ -408,6 +431,14 @@ func (c *bedrockChat) Send(ctx context.Context, contents ...any) (ChatResponse, 
 		input.ToolConfig = c.toolConfig
 	}
 
+	// Forward thinking/effort to the underlying Anthropic model via
+	// AdditionalModelRequestFields. Bedrock merges this into the model's
+	// native request body verbatim. The smithy document is built once in
+	// SetThinkingConfig and reused here on every turn.
+	if c.thinkingExtras != nil {
+		input.AdditionalModelRequestFields = c.thinkingExtras
+	}
+
 	// Call the Bedrock Converse API
 	output, err := c.client.client.Converse(ctx, input)
 	if err != nil {
@@ -483,6 +514,13 @@ func (c *bedrockChat) SendStreaming(ctx context.Context, contents ...any) (ChatR
 	// Add tool configuration if functions are defined
 	if c.toolConfig != nil {
 		input.ToolConfig = c.toolConfig
+	}
+
+	// Forward thinking/effort to the underlying Anthropic model via
+	// AdditionalModelRequestFields. Must mirror the populator in Send() so
+	// streaming and non-streaming paths produce identical wire payloads.
+	if c.thinkingExtras != nil {
+		input.AdditionalModelRequestFields = c.thinkingExtras
 	}
 
 	// Start the streaming request
@@ -742,6 +780,74 @@ func (c *bedrockChat) SetFunctionDefinitions(functions []*FunctionDefinition) er
 	return nil
 }
 
+// SetThinkingConfig configures extended thinking and effort for this chat.
+//
+// On Claude 4.6 models (Sonnet 4.6, Opus 4.6) accessed via Bedrock, this
+// causes subsequent Send/SendStreaming calls to populate
+// ConverseInput.AdditionalModelRequestFields with the corresponding
+// `thinking` and `output_config` keys, which Bedrock forwards verbatim to
+// the underlying Anthropic model. The smithy document is built once here
+// and cached on the chat — Send/SendStreaming reuse it for every turn.
+//
+// Parameters:
+//
+//	mode  - "" (off, do not send a thinking field), "adaptive", or "disabled".
+//	        On Sonnet 4.6 / Opus 4.6, "adaptive" is the recommended mode.
+//	        Anthropic deprecated `thinking.type=enabled` (the budget_tokens
+//	        flavor) on these models, so this method intentionally does not
+//	        accept it. Pass "" to leave the field unset.
+//	effort - "" (off, server defaults to "high"), "low", "medium", "high",
+//	         or "max". "max" is supported only on Opus 4.6 / Sonnet 4.6.
+//	         For Sonnet 4.6 agentic workloads, Anthropic recommends "medium".
+//
+// Both arguments are pass-through with no client-side validation. Bedrock
+// returns an error for unsupported combinations (e.g. effort on a non-4.6
+// model), and that error propagates through wrapAWSError unchanged.
+//
+// Calling SetThinkingConfig("", "") clears any previously-set values and
+// restores the default behavior (no additionalModelRequestFields sent).
+//
+// This method is a concrete extension on *bedrockChat (not part of the
+// generic gollm.Chat interface). Callers obtain it via a type assertion:
+//
+//	if tc, ok := chat.(interface{ SetThinkingConfig(mode, effort string) }); ok {
+//	    tc.SetThinkingConfig("adaptive", "medium")
+//	}
+func (c *bedrockChat) SetThinkingConfig(mode, effort string) {
+	c.thinkingMode = mode
+	c.effort = effort
+	if extras := c.extendedThinkingExtras(); extras != nil {
+		c.thinkingExtras = document.NewLazyDocument(extras)
+	} else {
+		c.thinkingExtras = nil
+	}
+}
+
+// extendedThinkingExtras returns the map that becomes
+// ConverseInput.AdditionalModelRequestFields once wrapped as a smithy
+// document. SetThinkingConfig wraps it; this helper is kept separate (and
+// in-package) so tests can assert on the raw key/value shape — the
+// smithy-go codec only unmarshals into typed structs, not generic maps,
+// so a round-trip-via-document assertion isn't workable in tests.
+//
+// The key names (`thinking`, `output_config`) match Anthropic's wire format
+// because Bedrock forwards AdditionalModelRequestFields verbatim to the
+// underlying model — it does not transform key names or values.
+func (c *bedrockChat) extendedThinkingExtras() map[string]any {
+	if c.thinkingMode == "" && c.effort == "" {
+		return nil
+	}
+
+	extras := make(map[string]any, 2)
+	if c.thinkingMode != "" {
+		extras["thinking"] = map[string]any{"type": c.thinkingMode}
+	}
+	if c.effort != "" {
+		extras["output_config"] = map[string]any{"effort": c.effort}
+	}
+	return extras
+}
+
 // IsRetryableError determines if an error is retryable and prints debug info
 func (c *bedrockChat) IsRetryableError(err error) bool {
 	var apiErr *APIError
@@ -995,12 +1101,72 @@ func wrapAWSError(err error) error {
 	return err
 }
 
+// claude46ShortNames is the canonical list of Claude 4.6 family model short
+// names. It's the single source of truth for both the alias map (which
+// resolves them to Bedrock IDs) and the IsClaude46Family predicate (which
+// gates the extended thinking / effort wire fields). When a new 4.6 family
+// model ships (e.g. Haiku 4.6), add it here and both consumers update.
+var claude46ShortNames = []string{
+	"claude-sonnet-4-6",
+	"claude-opus-4-6",
+}
+
+// bedrockModelAliases maps short model names to fully-qualified Bedrock model
+// IDs / cross-region inference profile IDs. This lets callers say
+// "claude-sonnet-4-6" without knowing the Bedrock-specific ARN form. Full
+// IDs (anything containing a dot) bypass this map and pass through verbatim.
+// Built from claude46ShortNames so the two stay in sync.
+var bedrockModelAliases = func() map[string]string {
+	m := make(map[string]string, len(claude46ShortNames))
+	for _, name := range claude46ShortNames {
+		m[name] = "global.anthropic." + name
+	}
+	return m
+}()
+
+// IsClaude46Family reports whether the given model identifier refers to a
+// Claude 4.6 family model (Sonnet 4.6, Opus 4.6, ...) — the only models on
+// Bedrock that currently accept the `thinking` and `output_config` fields.
+//
+// The check is intentionally substring-based so it covers every form a
+// caller might pass:
+//
+//   - short alias: "claude-sonnet-4-6"
+//   - global cross-region: "global.anthropic.claude-sonnet-4-6"
+//   - regional CRIS: "us.anthropic.claude-sonnet-4-6", "eu.anthropic..."
+//   - base regional: "anthropic.claude-sonnet-4-6"
+//
+// It deliberately does NOT match Sonnet 4 (no "-6" suffix), Sonnet 4.5
+// (different version path), Haiku 4.5 (different family), or Nova / Titan /
+// Llama (different providers entirely). Those models will error if you send
+// `output_config.effort` to them, so the gating must be precise.
+//
+// Exported so consumers (e.g. webserver decorators that wrap gollm.Client to
+// inject extended thinking config) can gate on the same definition the
+// Bedrock provider uses internally, instead of duplicating the model name
+// list and risking drift when a new 4.6 family member ships.
+func IsClaude46Family(model string) bool {
+	if model == "" {
+		return false
+	}
+	for _, name := range claude46ShortNames {
+		if strings.Contains(model, name) {
+			return true
+		}
+	}
+	return false
+}
+
 // getBedrockModel returns the model to use, checking in order:
-// 1. Explicitly provided model
+// 1. Explicitly provided model (resolved through bedrockModelAliases if it's a short name)
 // 2. Environment variable BEDROCK_MODEL
 // 3. Default model (Claude Sonnet 4)
 func getBedrockModel(model string) string {
 	if model != "" {
+		if resolved, ok := bedrockModelAliases[model]; ok {
+			klog.V(2).Infof("Resolved model alias %q -> %q", model, resolved)
+			return resolved
+		}
 		klog.V(2).Infof("Using explicitly provided model: %s", model)
 		return model
 	}

--- a/gollm/bedrock_thinking_test.go
+++ b/gollm/bedrock_thinking_test.go
@@ -1,0 +1,235 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gollm
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestIsClaude46Family covers the exported model-gating predicate. The
+// Bedrock provider and any external decorators (e.g. webserver wrappers
+// that inject extended thinking) rely on this to decide whether to forward
+// the `thinking` and `output_config` fields. Getting it wrong is a bug in
+// either direction:
+//
+//   - false positive (matching a non-4.6 model) → Bedrock returns an error
+//     when output_config.effort is forwarded
+//   - false negative (missing a real 4.6 model) → thinking is silently never
+//     enabled and the user wonders why responses don't have thinking blocks
+//
+// Both directions are tested here. Adding a new 4.6 family member to
+// claude46ShortNames should make new "should match" cases pass without any
+// other code change — that's the centralization payoff.
+func TestIsClaude46Family(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		// Should match — all the forms callers might pass
+		{"short alias sonnet 4.6", "claude-sonnet-4-6", true},
+		{"short alias opus 4.6", "claude-opus-4-6", true},
+		{"global cross-region sonnet", "global.anthropic.claude-sonnet-4-6", true},
+		{"global cross-region opus", "global.anthropic.claude-opus-4-6", true},
+		{"US regional CRIS sonnet", "us.anthropic.claude-sonnet-4-6", true},
+		{"EU regional CRIS opus", "eu.anthropic.claude-opus-4-6", true},
+		{"base regional sonnet", "anthropic.claude-sonnet-4-6", true},
+
+		// Must NOT match — these are real Bedrock models that would error
+		// on output_config.effort
+		{"empty string", "", false},
+		{"sonnet 4 (non-6)", "us.anthropic.claude-sonnet-4-20250514-v1:0", false},
+		{"sonnet 3.7", "us.anthropic.claude-3-7-sonnet-20250219-v1:0", false},
+		{"sonnet 4.5", "us.anthropic.claude-sonnet-4-5-20250929-v1:0", false},
+		{"opus 4.5", "us.anthropic.claude-opus-4-5-20251101-v1:0", false},
+		{"haiku 4.5", "us.anthropic.claude-haiku-4-5-20251001-v1:0", false},
+		{"nova pro", "us.amazon.nova-pro-v1:0", false},
+		{"completely unrelated", "llama-3-70b", false},
+
+		// Edge cases
+		{"prefix-only must not match", "claude-sonnet", false},
+		{"hypothetical 4-7 must not match 4-6", "claude-sonnet-4-7", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsClaude46Family(tt.model)
+			if got != tt.want {
+				t.Errorf("IsClaude46Family(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGetBedrockModel_Aliases verifies that the short model aliases for the
+// 4.6 family resolve to their fully-qualified Bedrock IDs, while full IDs
+// continue to pass through unchanged.
+func TestGetBedrockModel_Aliases(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "sonnet 4.6 alias resolves to global ID",
+			in:   "claude-sonnet-4-6",
+			want: "global.anthropic.claude-sonnet-4-6",
+		},
+		{
+			name: "opus 4.6 alias resolves to global ID",
+			in:   "claude-opus-4-6",
+			want: "global.anthropic.claude-opus-4-6",
+		},
+		{
+			name: "fully-qualified Sonnet 4 ID passes through",
+			in:   "us.anthropic.claude-sonnet-4-20250514-v1:0",
+			want: "us.anthropic.claude-sonnet-4-20250514-v1:0",
+		},
+		{
+			name: "fully-qualified Sonnet 4.6 ID passes through unchanged",
+			in:   "global.anthropic.claude-sonnet-4-6",
+			want: "global.anthropic.claude-sonnet-4-6",
+		},
+		{
+			name: "unknown short name passes through (Bedrock will reject)",
+			in:   "claude-not-a-real-model",
+			want: "claude-not-a-real-model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getBedrockModel(tt.in)
+			if got != tt.want {
+				t.Errorf("getBedrockModel(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBedrockChat_SetThinkingConfig_BuildsExtras is the load-bearing wire-
+// payload test. It exercises the SetThinkingConfig flow end-to-end:
+//
+//  1. Caller invokes SetThinkingConfig with the desired mode/effort
+//  2. The setter populates extendedThinkingExtras as the raw map (this is
+//     what we assert on, because the smithy-go document codec only
+//     unmarshals into typed structs, not generic maps)
+//  3. The setter caches the wrapped smithy document on c.thinkingExtras
+//     for Send/SendStreaming to use on every turn without rebuilding
+//
+// We assert both the raw map shape AND the cached-document nil-ness so
+// the contract Send/SendStreaming relies on stays locked in:
+// thinkingExtras is non-nil exactly when there are extras to send.
+//
+// If this test breaks, the on-the-wire JSON to Bedrock changed, which means
+// callers depending on adaptive thinking will silently regress.
+func TestBedrockChat_SetThinkingConfig_BuildsExtras(t *testing.T) {
+	tests := []struct {
+		name         string
+		thinkingMode string
+		effort       string
+		want         map[string]any // nil ⇒ no extras (default Bedrock behavior)
+	}{
+		{
+			name:         "both unset returns nil (preserves default Bedrock behavior)",
+			thinkingMode: "",
+			effort:       "",
+			want:         nil,
+		},
+		{
+			name:         "adaptive thinking only",
+			thinkingMode: "adaptive",
+			effort:       "",
+			want: map[string]any{
+				"thinking": map[string]any{"type": "adaptive"},
+			},
+		},
+		{
+			name:         "effort only",
+			thinkingMode: "",
+			effort:       "medium",
+			want: map[string]any{
+				"output_config": map[string]any{"effort": "medium"},
+			},
+		},
+		{
+			name:         "adaptive thinking with medium effort (recommended Sonnet 4.6 default)",
+			thinkingMode: "adaptive",
+			effort:       "medium",
+			want: map[string]any{
+				"thinking":      map[string]any{"type": "adaptive"},
+				"output_config": map[string]any{"effort": "medium"},
+			},
+		},
+		{
+			name:         "thinking disabled",
+			thinkingMode: "disabled",
+			effort:       "",
+			want: map[string]any{
+				"thinking": map[string]any{"type": "disabled"},
+			},
+		},
+		{
+			name:         "max effort with adaptive (Opus 4.6 high-stakes default)",
+			thinkingMode: "adaptive",
+			effort:       "max",
+			want: map[string]any{
+				"thinking":      map[string]any{"type": "adaptive"},
+				"output_config": map[string]any{"effort": "max"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chat := &bedrockChat{}
+			chat.SetThinkingConfig(tt.thinkingMode, tt.effort)
+
+			gotExtras := chat.extendedThinkingExtras()
+			if !reflect.DeepEqual(gotExtras, tt.want) {
+				t.Errorf("extendedThinkingExtras mismatch\n got:  %#v\n want: %#v", gotExtras, tt.want)
+			}
+
+			// thinkingExtras is what Send/SendStreaming actually use; assert
+			// the cached document is non-nil exactly when there are extras.
+			if (tt.want == nil) != (chat.thinkingExtras == nil) {
+				t.Errorf("thinkingExtras nil-ness mismatch: extras=%v cached doc nil? %v",
+					tt.want, chat.thinkingExtras == nil)
+			}
+		})
+	}
+}
+
+// TestBedrockChat_SetThinkingConfig_Clears verifies that calling
+// SetThinkingConfig with empty strings clears a previously-cached document.
+// This guards against a stale document being sent on a chat that was
+// configured and then explicitly reset to default behavior.
+func TestBedrockChat_SetThinkingConfig_Clears(t *testing.T) {
+	chat := &bedrockChat{}
+
+	chat.SetThinkingConfig("adaptive", "medium")
+	if chat.thinkingExtras == nil {
+		t.Fatal("expected non-nil thinkingExtras after configuring")
+	}
+
+	chat.SetThinkingConfig("", "")
+	if chat.thinkingExtras != nil {
+		t.Errorf("expected thinkingExtras to be cleared after SetThinkingConfig(\"\", \"\"), got %v", chat.thinkingExtras)
+	}
+	if chat.thinkingMode != "" || chat.effort != "" {
+		t.Errorf("expected mode/effort cleared, got mode=%q effort=%q", chat.thinkingMode, chat.effort)
+	}
+}


### PR DESCRIPTION
## Summary

Adds opt-in extended thinking and the `effort` parameter to the Bedrock provider for Claude Sonnet 4.6 / Opus 4.6 — the first models on Bedrock that accept the `thinking` and `output_config` fields.

Both fields are forwarded to the model via Bedrock Converse's `AdditionalModelRequestFields`, which Bedrock passes through verbatim to the underlying Anthropic model. Backwards compatible: chats that don't call `SetThinkingConfig` send no extra fields and behave identically to today.

### Why now

Anthropic deprecated `thinking.type=enabled` (the `budget_tokens` flavor) on Sonnet 4.6 / Opus 4.6 and replaced it with `thinking.type=adaptive`, where Claude decides per-request whether and how much to think. The `effort` parameter (`low` / `medium` / `high` / `max`) provides soft cost control across thinking depth, tool-call verbosity, and overall token spend. For Sonnet 4.6 agentic workloads, Anthropic explicitly recommends `effort=medium` as the default. Without this patch, Nirmata consumers (`go-llm-apps`, `go-nctl`, `ottoflow`) can't use Sonnet 4.6's full capabilities.

## What changed

- New `IsClaude46Family(model string) bool`, exported so external decorators (e.g. webserver wrappers) can gate on the same definition the Bedrock provider uses internally — no cross-repo drift when a new 4.6 family model ships.
- Driven by a single `claude46ShortNames` slice that also generates `bedrockModelAliases`. Adding a new 4.6 family member only requires updating one list.
- Short-name aliases (`claude-sonnet-4-6`, `claude-opus-4-6`) resolve through `getBedrockModel` to the corresponding `global.anthropic.*` cross-region inference profile, so callers don't need to know the Bedrock-specific ARN form.
- New `SetThinkingConfig(mode, effort string)` method on `*bedrockChat` (concrete extension, not on the generic `Chat` interface — accessed via type assertion to avoid forcing every other provider to stub it). The smithy document is built once in the setter and **cached** on the chat, so `Send` / `SendStreaming` reuse it on every turn instead of rebuilding map allocations on each call in agentic loops.
- `Send` and `SendStreaming` now populate `ConverseInput.AdditionalModelRequestFields` from the cached document when thinking is configured. Both call sites change in lockstep so streaming and non-streaming paths produce identical wire payloads.
- `ListModels` surfaces the new global cross-region IDs.

## Wire shape

When a caller does:

```go
chat := client.StartChat(systemPrompt, "claude-sonnet-4-6")
if tc, ok := chat.(interface{ SetThinkingConfig(mode, effort string) }); ok {
    tc.SetThinkingConfig("adaptive", "medium")
}
```

the resulting `ConverseInput.AdditionalModelRequestFields` is:

```json
{
  "thinking": { "type": "adaptive" },
  "output_config": { "effort": "medium" }
}
```

Bedrock forwards this verbatim to the model.

## Test plan

- [x] Unit tests for the model alias resolver (5 cases — short names resolve, full IDs pass through, unknown short names pass through unchanged)
- [x] Unit tests for `IsClaude46Family` (16 cases — every prefix form callers might pass + negative cases for Sonnet 4 / 4.5, Haiku 4.5, Nova, Llama, hypothetical 4-7)
- [x] Unit tests for the extras builder (6 cases — every combination of thinking + effort, plus the nil-when-empty contract)
- [x] Unit test for the clear-on-empty-args path
- [x] Full existing `go test ./...` suite still passes (no regressions in `bedrock_tools_test.go`)
- [x] `go vet ./...` clean
- [x] **End-to-end smoke test against live AWS Bedrock** with `claude-sonnet-4-6`: control call (no thinking) vs thinking call (adaptive + medium) on the same multi-step reasoning prompt. Both produced the correct answer (LCM of 1 through 10 = 2520). Output tokens went from 463 → 667 (**+44% on identical input**), which is direct evidence that extended thinking engaged server-side — extended thinking tokens are billed as output tokens, so a delta on the same prompt with the same model is the smoking gun. Wire shape was accepted by Bedrock without any 4xx.

## Backwards compatibility

100% — `bedrockChat.thinkingMode` / `effort` / `thinkingExtras` default to zero values. Existing callers that don't invoke `SetThinkingConfig` send no `additionalModelRequestFields` and behave identically to today's behavior on every model.