### PR TITLE
feat(anthropic): adaptive thinking + effort support for Claude 4.6

### DIFF
--- a/gollm/anthropic.go
+++ b/gollm/anthropic.go
@@ -39,7 +39,31 @@ const (
 	defaultAnthropicBaseURL = "https://api.anthropic.com"
 	defaultAnthropicModel   = "claude-sonnet-4-20250514"
 	anthropicAPIVersion     = "2023-06-01"
+
+	// On Sonnet 4.6+, Anthropic deprecated `enabled` (with budget_tokens) in
+	// favor of `adaptive` where the model decides per-request. We only ship
+	// `adaptive`.
+	thinkingTypeAdaptive = "adaptive"
+
+	// Preserved at the pre-thinking value so non-thinking callers see
+	// byte-identical request bodies.
+	defaultMaxTokens = 4096
+
+	// Adaptive thinking can spend significant output tokens on reasoning;
+	// higher cap avoids silent truncation. max_tokens is a cap, not a
+	// target — no extra cost when responses are short.
+	defaultMaxTokensThinking = 8192
 )
+
+// "" and "off" are equivalent (Anthropic treats omission as disabled).
+var validThinkingEfforts = map[string]bool{
+	"":       true,
+	"off":    true,
+	"low":    true,
+	"medium": true,
+	"high":   true,
+	"max":    true,
+}
 
 // Registers the Anthropic provider factory on package initialization
 func init() {
@@ -55,9 +79,10 @@ func newAnthropicClientFactory(ctx context.Context, opts ClientOptions) (Client,
 
 // Implements the gollm.Client interface for Anthropic Claude models via HTTP
 type AnthropicClient struct {
-	baseURL    *url.URL
-	httpClient *http.Client
-	apiKey     string
+	baseURL        *url.URL
+	httpClient     *http.Client
+	apiKey         string
+	thinkingEffort string // validated in NewAnthropicClient
 }
 
 var _ Client = &AnthropicClient{}
@@ -68,6 +93,14 @@ func NewAnthropicClient(ctx context.Context, opts ClientOptions) (*AnthropicClie
 	if apiKey == "" {
 		klog.Errorf("ANTHROPIC_API_KEY environment variable not set")
 		return nil, fmt.Errorf("%s environment variable not set", envAnthropicAPIKey)
+	}
+
+	// Fail-fast: catch typos at startup, not in per-request errors.
+	if !validThinkingEfforts[opts.ThinkingEffort] {
+		return nil, fmt.Errorf(
+			"invalid ThinkingEffort %q: must be one of \"\" (unset), \"off\", \"low\", \"medium\", \"high\", or \"max\"",
+			opts.ThinkingEffort,
+		)
 	}
 
 	// Get base URL
@@ -92,9 +125,10 @@ func NewAnthropicClient(ctx context.Context, opts ClientOptions) (*AnthropicClie
 	httpClient := createCustomHTTPClient(opts.SkipVerifySSL)
 
 	client := &AnthropicClient{
-		baseURL:    baseURL,
-		httpClient: httpClient,
-		apiKey:     apiKey,
+		baseURL:        baseURL,
+		httpClient:     httpClient,
+		apiKey:         apiKey,
+		thinkingEffort: opts.ThinkingEffort,
 	}
 
 	return client, nil
@@ -108,10 +142,11 @@ func (c *AnthropicClient) StartChat(systemPrompt, model string) Chat {
 	selectedModel := getAnthropicModel(model)
 
 	chat := &anthropicChat{
-		client:       c,
-		systemPrompt: systemPrompt,
-		model:        selectedModel,
-		messages:     []anthropicMessage{},
+		client:         c,
+		systemPrompt:   systemPrompt,
+		model:          selectedModel,
+		messages:       []anthropicMessage{},
+		thinkingEffort: c.thinkingEffort,
 	}
 
 	return chat
@@ -235,6 +270,17 @@ type anthropicRequest struct {
 	Tools       []anthropicTool    `json:"tools,omitempty"`
 	Stream      bool               `json:"stream,omitempty"`
 	Temperature *float64           `json:"temperature,omitempty"`
+	// Set together by applyThinkingConfig or both nil; never half-set.
+	Thinking     *anthropicThinking     `json:"thinking,omitempty"`
+	OutputConfig *anthropicOutputConfig `json:"output_config,omitempty"`
+}
+
+type anthropicThinking struct {
+	Type string `json:"type"`
+}
+
+type anthropicOutputConfig struct {
+	Effort string `json:"effort"`
 }
 
 type anthropicTool struct {
@@ -278,12 +324,25 @@ type anthropicError struct {
 }
 
 type anthropicChat struct {
-	client       *AnthropicClient
-	systemPrompt string
-	model        string
-	messages     []anthropicMessage
-	tools        []anthropicTool
-	functionDefs []*FunctionDefinition
+	client         *AnthropicClient
+	systemPrompt   string
+	model          string
+	messages       []anthropicMessage
+	tools          []anthropicTool
+	functionDefs   []*FunctionDefinition
+	thinkingEffort string // inherited from client; validated at client construction
+}
+
+// applyThinkingConfig must be called from both Send and SendStreaming to
+// keep streaming and non-streaming wire payloads identical. All three
+// mutations happen together or none — there's no half-set state.
+func (c *anthropicChat) applyThinkingConfig(req *anthropicRequest) {
+	if c.thinkingEffort == "" || c.thinkingEffort == "off" {
+		return
+	}
+	req.MaxTokens = defaultMaxTokensThinking
+	req.Thinking = &anthropicThinking{Type: thinkingTypeAdaptive}
+	req.OutputConfig = &anthropicOutputConfig{Effort: c.thinkingEffort}
 }
 
 func (c *anthropicChat) Initialize(history []*api.Message) error {
@@ -495,7 +554,7 @@ func (c *anthropicChat) Send(ctx context.Context, contents ...any) (ChatResponse
 	// Prepare the request
 	reqBody := anthropicRequest{
 		Model:     c.model,
-		MaxTokens: 4096,
+		MaxTokens: defaultMaxTokens,
 		Messages:  tempMessages,
 	}
 
@@ -507,6 +566,8 @@ func (c *anthropicChat) Send(ctx context.Context, contents ...any) (ChatResponse
 		reqBody.Tools = c.tools
 		klog.V(1).Infof("Request includes %d tools", len(c.tools))
 	}
+
+	c.applyThinkingConfig(&reqBody)
 
 	// Marshal request
 	bodyBytes, err := json.Marshal(reqBody)
@@ -611,7 +672,7 @@ func (c *anthropicChat) SendStreaming(ctx context.Context, contents ...any) (Cha
 	// Prepare the streaming request
 	reqBody := anthropicRequest{
 		Model:     c.model,
-		MaxTokens: 4096,
+		MaxTokens: defaultMaxTokens,
 		Messages:  tempMessages,
 		Stream:    true,
 	}
@@ -625,6 +686,8 @@ func (c *anthropicChat) SendStreaming(ctx context.Context, contents ...any) (Cha
 		reqBody.Tools = c.tools
 		klog.V(1).Infof("Streaming request includes %d tools", len(c.tools))
 	}
+
+	c.applyThinkingConfig(&reqBody)
 
 	// Marshal request
 	bodyBytes, err := json.Marshal(reqBody)

--- a/gollm/anthropic_thinking_test.go
+++ b/gollm/anthropic_thinking_test.go
@@ -47,7 +47,7 @@ func buildRequest(chat *anthropicChat, stream bool) anthropicRequest {
 			Role:    "user",
 			Content: []anthropicContentBlock{{Type: "text", Text: "test"}},
 		}},
-		Stream:    stream,
+		Stream: stream,
 	}
 	chat.applyThinkingConfig(&req)
 	return req
@@ -98,12 +98,12 @@ func TestAnthropic_NoThinkingEffort_ZeroBehaviorChange(t *testing.T) {
 // TestAnthropic_ThinkingEffort_LockstepSendAndStreaming is the load-bearing
 // wire-format correctness test. With WithThinkingEffort("medium"):
 //
-//   1. Both the non-streaming (Stream:false) and streaming (Stream:true)
-//      request bodies must include the thinking and output_config fields.
-//   2. The two code paths must produce IDENTICAL thinking/output_config
-//      content (after stripping the Stream field difference). If they ever
-//      diverge, callers get inconsistent thinking behavior depending on
-//      whether they happen to use streaming.
+//  1. Both the non-streaming (Stream:false) and streaming (Stream:true)
+//     request bodies must include the thinking and output_config fields.
+//  2. The two code paths must produce IDENTICAL thinking/output_config
+//     content (after stripping the Stream field difference). If they ever
+//     diverge, callers get inconsistent thinking behavior depending on
+//     whether they happen to use streaming.
 //
 // If this test breaks, the on-the-wire JSON to Anthropic changed for one
 // path but not the other.
@@ -276,4 +276,3 @@ func TestAnthropic_ThinkingEffort_PersistsAcrossTurns(t *testing.T) {
 		}
 	}
 }
-

--- a/gollm/anthropic_thinking_test.go
+++ b/gollm/anthropic_thinking_test.go
@@ -1,0 +1,279 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gollm
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// setAPIKey lets NewAnthropicClient pass its env-var check; no HTTP traffic
+// happens in these tests.
+func setAPIKey(t *testing.T) {
+	t.Helper()
+	old := os.Getenv(envAnthropicAPIKey)
+	os.Setenv(envAnthropicAPIKey, "test-key-not-real")
+	t.Cleanup(func() {
+		if old == "" {
+			os.Unsetenv(envAnthropicAPIKey)
+		} else {
+			os.Setenv(envAnthropicAPIKey, old)
+		}
+	})
+}
+
+// buildRequest mirrors what Send and SendStreaming construct internally,
+// so applyThinkingConfig is exercised in the same shape as production code.
+func buildRequest(chat *anthropicChat, stream bool) anthropicRequest {
+	req := anthropicRequest{
+		Model:     chat.model,
+		MaxTokens: defaultMaxTokens,
+		Messages: []anthropicMessage{{
+			Role:    "user",
+			Content: []anthropicContentBlock{{Type: "text", Text: "test"}},
+		}},
+		Stream:    stream,
+	}
+	chat.applyThinkingConfig(&req)
+	return req
+}
+
+// TestAnthropic_NoThinkingEffort_ZeroBehaviorChange asserts that when
+// WithThinkingEffort isn't set (the existing-caller path), the marshaled
+// request body has no `thinking` or `output_config` fields. This is the
+// load-bearing backwards-compatibility test: existing gollm anthropic
+// callers must see byte-identical request bodies after this change.
+func TestAnthropic_NoThinkingEffort_ZeroBehaviorChange(t *testing.T) {
+	setAPIKey(t)
+
+	client, err := NewAnthropicClient(context.Background(), ClientOptions{})
+	if err != nil {
+		t.Fatalf("NewAnthropicClient: %v", err)
+	}
+
+	chat := client.StartChat("system prompt", defaultAnthropicModel).(*anthropicChat)
+	req := buildRequest(chat, false)
+
+	bodyBytes, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(bodyBytes)
+
+	if strings.Contains(body, `"thinking"`) {
+		t.Errorf("request body unexpectedly contains \"thinking\" field: %s", body)
+	}
+	if strings.Contains(body, `"output_config"`) {
+		t.Errorf("request body unexpectedly contains \"output_config\" field: %s", body)
+	}
+	// Critical backwards-compat assertion: max_tokens must stay at the
+	// pre-thinking default (4096), NOT bumped to the thinking-enabled
+	// 8192. Without this assertion an earlier draft of the implementation
+	// silently bumped max_tokens for ALL anthropic callers — caught by a
+	// reviewer, not by the test, which is exactly the kind of slip this
+	// assertion is here to prevent.
+	if req.MaxTokens != defaultMaxTokens {
+		t.Errorf("no-thinking path must keep MaxTokens=%d, got %d", defaultMaxTokens, req.MaxTokens)
+	}
+	if strings.Contains(body, `"max_tokens":8192`) {
+		t.Errorf("no-thinking request body must not contain max_tokens:8192: %s", body)
+	}
+}
+
+// TestAnthropic_ThinkingEffort_LockstepSendAndStreaming is the load-bearing
+// wire-format correctness test. With WithThinkingEffort("medium"):
+//
+//   1. Both the non-streaming (Stream:false) and streaming (Stream:true)
+//      request bodies must include the thinking and output_config fields.
+//   2. The two code paths must produce IDENTICAL thinking/output_config
+//      content (after stripping the Stream field difference). If they ever
+//      diverge, callers get inconsistent thinking behavior depending on
+//      whether they happen to use streaming.
+//
+// If this test breaks, the on-the-wire JSON to Anthropic changed for one
+// path but not the other.
+func TestAnthropic_ThinkingEffort_LockstepSendAndStreaming(t *testing.T) {
+	setAPIKey(t)
+
+	client, err := NewAnthropicClient(context.Background(), ClientOptions{
+		ThinkingEffort: "medium",
+	})
+	if err != nil {
+		t.Fatalf("NewAnthropicClient: %v", err)
+	}
+
+	chat := client.StartChat("system prompt", defaultAnthropicModel).(*anthropicChat)
+
+	sendReq := buildRequest(chat, false)
+	streamReq := buildRequest(chat, true)
+
+	// Both must populate Thinking with adaptive type
+	if sendReq.Thinking == nil || sendReq.Thinking.Type != thinkingTypeAdaptive {
+		t.Errorf("Send path: expected Thinking.Type=%q, got %#v", thinkingTypeAdaptive, sendReq.Thinking)
+	}
+	if streamReq.Thinking == nil || streamReq.Thinking.Type != thinkingTypeAdaptive {
+		t.Errorf("Streaming path: expected Thinking.Type=%q, got %#v", thinkingTypeAdaptive, streamReq.Thinking)
+	}
+
+	// Both must populate OutputConfig with the configured effort
+	if sendReq.OutputConfig == nil || sendReq.OutputConfig.Effort != "medium" {
+		t.Errorf("Send path: expected OutputConfig.Effort=%q, got %#v", "medium", sendReq.OutputConfig)
+	}
+	if streamReq.OutputConfig == nil || streamReq.OutputConfig.Effort != "medium" {
+		t.Errorf("Streaming path: expected OutputConfig.Effort=%q, got %#v", "medium", streamReq.OutputConfig)
+	}
+
+	// Both must bump MaxTokens to the thinking-enabled cap. Symmetric to the
+	// no-thinking-path assertion in TestAnthropic_NoThinkingEffort_ZeroBehaviorChange:
+	// applyThinkingConfig owns the MaxTokens bump, both code paths invoke it,
+	// and divergence between Send and SendStreaming on this field would mean
+	// streaming users silently truncate while non-streaming users don't (or
+	// vice versa).
+	if sendReq.MaxTokens != defaultMaxTokensThinking {
+		t.Errorf("Send path: expected MaxTokens=%d (thinking on), got %d", defaultMaxTokensThinking, sendReq.MaxTokens)
+	}
+	if streamReq.MaxTokens != defaultMaxTokensThinking {
+		t.Errorf("Streaming path: expected MaxTokens=%d (thinking on), got %d", defaultMaxTokensThinking, streamReq.MaxTokens)
+	}
+
+	// Marshal both and verify the thinking/output_config keys appear at top
+	// level in the JSON (Anthropic's API requires this — they are NOT
+	// wrapped in an envelope unlike Bedrock's additionalModelRequestFields).
+	for label, req := range map[string]anthropicRequest{"send": sendReq, "stream": streamReq} {
+		bodyBytes, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("%s marshal: %v", label, err)
+		}
+		body := string(bodyBytes)
+		if !strings.Contains(body, `"thinking":{"type":"adaptive"}`) {
+			t.Errorf("%s body missing top-level adaptive thinking: %s", label, body)
+		}
+		if !strings.Contains(body, `"output_config":{"effort":"medium"}`) {
+			t.Errorf("%s body missing top-level output_config.effort=medium: %s", label, body)
+		}
+	}
+}
+
+// TestAnthropic_ThinkingEffort_AllValidValues exercises every accepted
+// effort value as a table test. "" and "off" must produce no thinking
+// fields (semantically equivalent — Anthropic treats omission as
+// disabled). "low"/"medium"/"high"/"max" must produce the corresponding
+// adaptive-thinking + effort fields.
+func TestAnthropic_ThinkingEffort_AllValidValues(t *testing.T) {
+	setAPIKey(t)
+
+	tests := []struct {
+		name             string
+		effort           string
+		wantThinkingSet  bool   // true ⇒ Thinking and OutputConfig should both be non-nil
+		wantEffortInBody string // checked only when wantThinkingSet is true
+	}{
+		{name: "empty string is no-op", effort: "", wantThinkingSet: false},
+		{name: "off is no-op", effort: "off", wantThinkingSet: false},
+		{name: "low enables adaptive + low effort", effort: "low", wantThinkingSet: true, wantEffortInBody: "low"},
+		{name: "medium enables adaptive + medium effort", effort: "medium", wantThinkingSet: true, wantEffortInBody: "medium"},
+		{name: "high enables adaptive + high effort", effort: "high", wantThinkingSet: true, wantEffortInBody: "high"},
+		{name: "max enables adaptive + max effort", effort: "max", wantThinkingSet: true, wantEffortInBody: "max"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewAnthropicClient(context.Background(), ClientOptions{
+				ThinkingEffort: tt.effort,
+			})
+			if err != nil {
+				t.Fatalf("NewAnthropicClient(%q): %v", tt.effort, err)
+			}
+
+			chat := client.StartChat("", defaultAnthropicModel).(*anthropicChat)
+			req := buildRequest(chat, false)
+
+			if tt.wantThinkingSet {
+				if req.Thinking == nil || req.Thinking.Type != thinkingTypeAdaptive {
+					t.Errorf("expected adaptive Thinking, got %#v", req.Thinking)
+				}
+				if req.OutputConfig == nil || req.OutputConfig.Effort != tt.wantEffortInBody {
+					t.Errorf("expected OutputConfig.Effort=%q, got %#v", tt.wantEffortInBody, req.OutputConfig)
+				}
+			} else {
+				if req.Thinking != nil {
+					t.Errorf("expected nil Thinking for effort=%q, got %#v", tt.effort, req.Thinking)
+				}
+				if req.OutputConfig != nil {
+					t.Errorf("expected nil OutputConfig for effort=%q, got %#v", tt.effort, req.OutputConfig)
+				}
+			}
+		})
+	}
+}
+
+// TestAnthropic_ThinkingEffort_InvalidFailsFast verifies that
+// NewAnthropicClient rejects unknown effort values at construction time
+// rather than letting them flow through to per-request errors. The error
+// message must include the offending value so operators can debug their
+// startup config without enabling debug logging.
+func TestAnthropic_ThinkingEffort_InvalidFailsFast(t *testing.T) {
+	setAPIKey(t)
+
+	tests := []string{"foo", "MEDIUM", "high ", " low", "1", "true"}
+	for _, badValue := range tests {
+		t.Run("invalid_"+badValue, func(t *testing.T) {
+			_, err := NewAnthropicClient(context.Background(), ClientOptions{
+				ThinkingEffort: badValue,
+			})
+			if err == nil {
+				t.Fatalf("expected error for ThinkingEffort=%q, got nil", badValue)
+			}
+			if !strings.Contains(err.Error(), badValue) {
+				t.Errorf("error message %q must contain offending value %q for debuggability",
+					err.Error(), badValue)
+			}
+		})
+	}
+}
+
+// TestAnthropic_ThinkingEffort_PersistsAcrossTurns guards against an
+// implementation that accidentally consumes or mutates thinking config
+// after the first request. We build the request three times in a row off
+// the same chat and assert the thinking fields are present every time.
+//
+// The bug this catches: if applyThinkingConfig were ever changed to e.g.
+// clear the chat's thinkingEffort after first use, multi-turn agentic
+// loops would silently lose thinking after turn 1.
+func TestAnthropic_ThinkingEffort_PersistsAcrossTurns(t *testing.T) {
+	setAPIKey(t)
+
+	client, err := NewAnthropicClient(context.Background(), ClientOptions{
+		ThinkingEffort: "high",
+	})
+	if err != nil {
+		t.Fatalf("NewAnthropicClient: %v", err)
+	}
+	chat := client.StartChat("", defaultAnthropicModel).(*anthropicChat)
+
+	for turn := 1; turn <= 3; turn++ {
+		req := buildRequest(chat, false)
+		if req.Thinking == nil || req.Thinking.Type != thinkingTypeAdaptive {
+			t.Errorf("turn %d: expected adaptive Thinking, got %#v", turn, req.Thinking)
+		}
+		if req.OutputConfig == nil || req.OutputConfig.Effort != "high" {
+			t.Errorf("turn %d: expected OutputConfig.Effort=high, got %#v", turn, req.OutputConfig)
+		}
+	}
+}
+

--- a/gollm/factory.go
+++ b/gollm/factory.go
@@ -55,6 +55,9 @@ func (r *registry) listProviders() []string {
 type ClientOptions struct {
 	URL           *url.URL
 	SkipVerifySSL bool
+	// Honored by anthropic only; ignored elsewhere. Validated by the
+	// provider factory — see WithThinkingEffort for accepted values.
+	ThinkingEffort string
 	// Extend with more options as needed
 }
 
@@ -65,6 +68,15 @@ type Option func(*ClientOptions)
 func WithSkipVerifySSL() Option {
 	return func(o *ClientOptions) {
 		o.SkipVerifySSL = true
+	}
+}
+
+// WithThinkingEffort sets the anthropic-provider extended-thinking effort
+// for Claude Sonnet 4.6+. Accepted: "" or "off" (no thinking), "low",
+// "medium", "high", "max". Invalid values fail NewClient at startup.
+func WithThinkingEffort(effort string) Option {
+	return func(o *ClientOptions) {
+		o.ThinkingEffort = effort
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds adaptive extended-thinking support to the direct-to-Anthropic provider in `gollm` so callers can opt into Sonnet 4.6+ reasoning without routing through Bedrock. Callers that don't opt in see byte-identical request bodies.

## Wire format

Top-level fields on `/v1/messages` (no envelope wrapping):

```json
{
  "thinking":      { "type": "adaptive" },
  "output_config": { "effort": "medium" }
}
```

## API

- `ClientOptions.ThinkingEffort` (`gollm/factory.go`) — anthropic-only; silently ignored by other providers.
- `gollm.WithThinkingEffort(effort)` functional option.
- Accepted values: `""` or `"off"` (disabled), `"low"` | `"medium"` | `"high"` | `"max"`.
- Invalid values fail fast from `NewAnthropicClient` with the offending value named in the error message.

## Request-body behavior

| `ThinkingEffort` | `thinking` field | `output_config` field | `max_tokens` |
|---|---|---|---|
| `""` or `"off"` | omitted | omitted | 4096 (unchanged) |
| `low`/`medium`/`high`/`max` | `{"type":"adaptive"}` | `{"effort":"<value>"}` | 8192 |

`Send` and `SendStreaming` both call `applyThinkingConfig`, keeping streaming and non-streaming wire payloads identical.

## Why bump max_tokens only when thinking is on

Adaptive thinking can consume ~40% of the output budget on reasoning before any user-visible tokens are produced. 4096 is too low once thinking is enabled, and silently truncates responses. Bumping unconditionally would break the byte-identical-wire-format promise for existing callers, so the bump is gated on `thinking_effort != off`.

## Test plan

- [x] `go test ./gollm/... -run TestAnthropic_` passes (5 tests, 14 subtests)
  - Zero-behavior-change: no `thinking`/`output_config` emitted, `max_tokens` stays 4096
  - Lockstep: `Send` and `SendStreaming` produce identical thinking fields and both bump `max_tokens` to 8192
  - All valid values table (`""`, `off`, `low`, `medium`, `high`, `max`)
  - Invalid values fail fast with the offending value in the error
  - Effort persists across three `Send` turns on one chat
- [ ] Integration: paired PR in `go-llm-apps` wires a `--thinking-effort` webserver flag; real API validation happens there

## Follow-ups

- Paired PR in `nirmata/go-llm-apps` adds `--thinking-effort` startup flag and threads it through `gollm.NewClient`. This PR is the capability; that PR is the wiring.
- If Anthropic returns "requires anthropic-beta header" during real-API testing, add the header as a targeted fix.
