### PR TITLE
fix(bedrock): merge consecutive same-role messages in Initialize

### DIFF
--- a/gollm/bedrock.go
+++ b/gollm/bedrock.go
@@ -184,6 +184,24 @@ func (cs *bedrockChat) Initialize(history []*api.Message) error {
 		cs.messages = append(cs.messages, bedrockMsg)
 	}
 
+	// Bedrock's Converse API requires strictly alternating user/assistant turns.
+	// Parallel tool calls from a single assistant turn arrive here as multiple
+	// separate messages (one per tool_use or tool_result); collapse any run of
+	// consecutive same-role messages into one so tool_use and tool_result blocks
+	// stay paired within their original turn.
+	if len(cs.messages) > 1 {
+		merged := cs.messages[:1]
+		for _, msg := range cs.messages[1:] {
+			last := &merged[len(merged)-1]
+			if msg.Role == last.Role {
+				last.Content = append(last.Content, msg.Content...)
+				continue
+			}
+			merged = append(merged, msg)
+		}
+		cs.messages = merged
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Bedrock's Converse API requires strictly alternating user/assistant turns
- Parallel tool calls persisted as separate `api.Message` entries (one per `tool_use`/`tool_result`) produce consecutive same-role messages, causing Bedrock to reject with _"The number of toolResult blocks … exceeds the number of toolUse blocks of previous turn."_
- Collapse any run of consecutive same-role messages into one at the end of `Initialize` so `tool_use` and `tool_result` blocks remain grouped within their original turn

## Test plan

Tested manually: parallel tool calls against a Bedrock-backed model complete successfully without a `ValidationException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)