### PR TITLE
fix(gollm): surface error on tool input JSON unmarshal failure

### DIFF
--- a/gollm/bedrock.go
+++ b/gollm/bedrock.go
@@ -614,8 +614,12 @@ func (c *bedrockChat) SendStreaming(ctx context.Context, contents ...any) (ChatR
 							continue
 						}
 					} else {
-						klog.V(2).Infof("Tool %q: content block completed with empty input", partial.name)
-						args = make(map[string]any)
+						klog.Errorf("Tool %q: content block completed with no input deltas (expected at least '{}')", partial.name)
+						if !yield(nil, fmt.Errorf("tool %q: no input deltas received", partial.name)) {
+							return
+						}
+						delete(partialTools, idx)
+						continue
 					}
 
 					// Create ToolUseBlock for conversation history

--- a/gollm/bedrock.go
+++ b/gollm/bedrock.go
@@ -614,12 +614,8 @@ func (c *bedrockChat) SendStreaming(ctx context.Context, contents ...any) (ChatR
 							continue
 						}
 					} else {
-						klog.Errorf("Tool %q: content block completed with no input deltas (expected at least '{}')", partial.name)
-						if !yield(nil, fmt.Errorf("tool %q: no input deltas received", partial.name)) {
-							return
-						}
-						delete(partialTools, idx)
-						continue
+						klog.V(2).Infof("Tool %q: content block completed with empty input", partial.name)
+						args = make(map[string]any)
 					}
 
 					// Create ToolUseBlock for conversation history

--- a/gollm/bedrock.go
+++ b/gollm/bedrock.go
@@ -606,9 +606,15 @@ func (c *bedrockChat) SendStreaming(ctx context.Context, contents ...any) (ChatR
 					var args map[string]any
 					if inputJSON != "" {
 						if err := json.Unmarshal([]byte(inputJSON), &args); err != nil {
-							args = make(map[string]any)
+							klog.Errorf("Tool %q: failed to unmarshal input JSON: %v (raw: %s)", partial.name, err, inputJSON)
+							if !yield(nil, fmt.Errorf("tool %q input JSON unmarshal failed: %w", partial.name, err)) {
+								return
+							}
+							delete(partialTools, idx)
+							continue
 						}
 					} else {
+						klog.V(2).Infof("Tool %q: content block completed with empty input", partial.name)
 						args = make(map[string]any)
 					}
 
@@ -974,7 +980,7 @@ func (p *bedrockToolPart) AsFunctionCalls() ([]FunctionCall, bool) {
 	} else if p.toolUse.Input != nil {
 		// Non-streaming case - unmarshal from Input
 		if err := p.toolUse.Input.UnmarshalSmithyDocument(&args); err != nil {
-			klog.V(2).Infof("Failed to unmarshal tool input: %v", err)
+			klog.Errorf("Tool %q: failed to unmarshal input: %v", aws.ToString(p.toolUse.Name), err)
 			args = make(map[string]any)
 		}
 	} else {


### PR DESCRIPTION
## Summary

- When Bedrock streaming accumulates malformed tool input JSON, the client was silently substituting an empty `map[string]any{}` — no log, no error. This caused the agent loop to execute tool calls with zero arguments, which failed downstream with confusing "required parameter" errors and triggered costly retry loops.
- Now yields a stream error on unmarshal failure so the caller can handle it, and logs at V(2) when input is empty (legitimate zero-arg tool calls still work).
- Upgrades the non-streaming path log from V(2) to `klog.Errorf` for unmarshal failures.

## Test plan

- [ ] Verify tool calls with valid arguments still work end-to-end
- [ ] Verify zero-argument tool calls still work (empty input path unchanged)
- [ ] Verify malformed tool input now surfaces an error to the caller instead of silently proceeding with empty args
- [ ] Run existing `go test ./gollm/...` (pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)